### PR TITLE
Allow extending the sequence beyond the pattern

### DIFF
--- a/McSequencer/ArthurMcArthur_McSequencer.lua
+++ b/McSequencer/ArthurMcArthur_McSequencer.lua
@@ -1368,7 +1368,7 @@ local function getSelectedPatternItemAndMidiItem(trackIndex, patternItems, patte
         local item_length = reaper.GetMediaItemInfo_Value(item, "D_LENGTH")
         local item_end = item_start + item_length
 
-        if nearlyEqual(item_start, pattern_start, float_epsilon) and nearlyEqual(item_end, pattern_end, float_epsilon) then
+        if nearlyEqual(item_start, pattern_start, float_epsilon) then
             local take = reaper.GetMediaItemTake(item, 0)
             if reaper.TakeIsMIDI(take) then
                 return pattern_item, pattern_start, pattern_end, item, track


### PR DESCRIPTION
Currently, If I want to create a song I need to repeat a pattern a number of times.

Doing this on the sequence creates a compromise: either increase the size of the pattern just to repeat it, or keep the pattern short but extend the SEQ channel so it loops.

The problem with the second option is that as soon as I change the item size, the sequencer stops recognizing the sequence, so further changes are not allowed using the script.

This PR fixes that, now you can expand your items to loop multiple times! and since it's a copy any change on the pattern will be reflected on each copy!
![Screenshot 2025-06-08 114143](https://github.com/user-attachments/assets/e40c9cce-ab06-4aed-8cc0-a31df245ef62)
